### PR TITLE
Build backend production dependencies

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -41,8 +41,12 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 COPY prisma ./prisma
 
-# Устанавливаем только production зависимости
-RUN pnpm install --frozen-lockfile --prod --silent
+# Устанавливаем только production зависимости, пропускаем postinstall скрипт
+RUN pnpm install --frozen-lockfile --prod --silent --ignore-scripts
+
+# Копируем сгенерированный Prisma клиент из build этапа
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/@prisma/client ./node_modules/@prisma/client
 
 # Копируем собранные файлы
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
Fix backend Docker build by correctly handling Prisma client generation for production.

The `sh: prisma: not found` error occurred because the `prisma generate` postinstall script ran in the production stage where Prisma CLI (a dev dependency) was not present. This PR skips the postinstall script in production and copies the pre-generated Prisma client from the build stage.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c589392-685c-40e5-a89d-184947ff2c0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c589392-685c-40e5-a89d-184947ff2c0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

