### PR TITLE
Fix prisma copy in dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -44,9 +44,10 @@ COPY prisma ./prisma
 # Устанавливаем только production зависимости, пропускаем postinstall скрипт
 RUN pnpm install --frozen-lockfile --prod --silent --ignore-scripts
 
-# Копируем сгенерированный Prisma клиент из build этапа
-COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=build /app/node_modules/@prisma/client ./node_modules/@prisma/client
+# Генерируем Prisma клиент в production stage
+RUN pnpm prisma generate
+
+# Копируем собранные файлы TypeScript из build stage
 
 # Копируем собранные файлы
 COPY --from=build /app/dist ./dist


### PR DESCRIPTION
Generate Prisma client directly in the backend production Docker stage to fix build errors caused by missing client files.

The previous setup failed because `pnpm install --ignore-scripts` in the production stage prevented the `prisma generate` script from running, making the Prisma client files unavailable for copying from the build stage. Explicitly running `pnpm prisma generate` in the production stage ensures the client is generated correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5744695b-782f-4c57-8592-07984d3271a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5744695b-782f-4c57-8592-07984d3271a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

