### PR TITLE
Fix prisma command not found in backend build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,9 @@ COPY . .
 # Собираем TypeScript
 RUN pnpm run build
 
+# Генерируем Prisma клиент в build stage (где есть dev-зависимости)
+RUN pnpm prisma generate
+
 # Этап продакшн
 FROM node:20-alpine AS production
 ENV PNPM_HOME="/pnpm"
@@ -44,13 +47,14 @@ COPY prisma ./prisma
 # Устанавливаем только production зависимости, пропускаем postinstall скрипт
 RUN pnpm install --frozen-lockfile --prod --silent --ignore-scripts
 
-# Генерируем Prisma клиент в production stage
-RUN pnpm prisma generate
-
 # Копируем собранные файлы TypeScript из build stage
 
 # Копируем собранные файлы
 COPY --from=build /app/dist ./dist
+
+# Копируем сгенерированный Prisma клиент из build stage
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/node_modules/@prisma/client ./node_modules/@prisma/client
 
 # Убеждаемся, что package.json скопирован для pnpm start
 COPY --from=build /app/package.json ./package.json


### PR DESCRIPTION
Move Prisma client generation to the build stage and copy it to production to resolve "command not found" errors.

The `prisma` CLI tool is a devDependency and was not available in the production stage where `pnpm install --prod` was used, leading to the "Command 'prisma' not found" error during `pnpm prisma generate`. This change ensures the client is generated where `prisma` is available and then copied for runtime use.

---
<a href="https://cursor.com/background-agent?bcId=bc-1974e4e8-94f9-4351-b056-4ee97e2c5d3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1974e4e8-94f9-4351-b056-4ee97e2c5d3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

